### PR TITLE
Additions to README, Dockerfile and about.html

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
 FROM ubuntu:latest
+RUN apt-get update && apt-get install -y nginx python3 python3-pip gettext-base
+RUN pip3 install --upgrade pip
+RUN pip3 install uwsgi
 RUN mkdir /code
 EXPOSE 80
 ENV OCAMLSPEED_DB_LOCATION /data/data.db
 WORKDIR /code
 COPY . /code/
-RUN apt-get update && apt-get install -y nginx python3 python3-pip gettext-base
-RUN pip3 install --upgrade pip
-RUN pip3 install -e . && pip3 install uwsgi
+RUN pip3 install -e .
 RUN mv ocamlspeed/deploy/nginx.default-site.conf /etc/nginx/sites-enabled/default
 CMD ./prepare_and_start.sh

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ OCamlspeed is a web application to monitor and analyze performance.
 
 The master branch is automatically built as a docker image and published to the [ocamlbench/ocamlspeed](https://hub.docker.com/r/ocamlbench/ocamlspeed) image on docker hub.
 
-To deploy using docker compose, for an environment with a single ocamlspeed running you will need a config that looks like the following:
+To deploy using docker compose, for an environment with a single ocamlspeed running you will need to create a `docker-compose.yml` file that looks like the following:
 
 ```
 version: '3'
@@ -16,11 +16,14 @@ services:
     environment:
       - OCAMLSPEED_HOST=examplespeed.example.com
       - OCAMLSPEED_NAME=example
-      - OCAMLSPEED_DESCRIPTION=This is an example ocamlspeed deploy
       - OCAMLSPEED_LOGO=http://www.example.com/example.icon.png
       - OCAMLSPEED_SECRET_KEY=pickarandomsecretkeyherethatsbetterthanthis
       - OCAMLSPEED_NORMALIZE=true
-    ports: 
+      - OCAMLSPEED_ABOUT_THIS_SITE_BLOCK=<p>This is a demo of benchmarks run on various compilers</p>
+      - OCAMLSPEED_ABOUT_BENCHMARKS_BLOCK=<p>The benchmarking code can be found <a href="https://a_link_to_somewhere/">here</a>.</p>
+      - OCAMLSPEED_ABOUT_MYPROJECT_BLOCK=<p>The compiler code can be found <a href="https://github.com/somewhere">here</a>.</p>
+      - OCAMLSPEED_ABOUT_CONTACT_BLOCK=<p>For problems or suggestions about this website write to somebody@somewhere.com</p>
+    ports:
         - "8080:80"
     volumes:
         - "./example-data:/data/"
@@ -29,4 +32,10 @@ services:
 
 This assumes you want the example ocamlspeed instance running on port 8080 on the local machine and you have two directories example-data and example-artifacts in the current directory which will be used for the database and run artifacts respectively.
 
+The environment variables (`OCAMLSPEED_...`) in the `docker-compose.yml` file allow you to configure various aspects of the site. You can grep the codebase for `OCAMLSPEED_` to find more configuration hooks; for example there are some in `ocamlspeed/settings.py`.
+
 After this you can run ```docker-compose up -d``` to start the environment.
+
+## Development
+
+While developing a change, you can build the Docker container from the local Dockerfile by replacing `image: ocamlbench/ocamlspeed` and with `build: .`. You can then run ```docker-compose up -d --build``` locally to build and run a test instance.

--- a/ocamlspeed/templates/about.html
+++ b/ocamlspeed/templates/about.html
@@ -5,18 +5,17 @@
 </div>
 <div id="about" class="about_content clearfix">
 <h3>About this site</h3>
-<p>${OCAMLSPEED_DESCRIPTION}</p>
+${OCAMLSPEED_ABOUT_THIS_SITE_BLOCK}
 <p>This site runs on top of Django and a modified verison of Codespeed</p>
 <h3>About the benchmarks</h3>
-<p>The operf-micro code can be found <a href="https://github.com/OCamlPro/operf-micro">here</a>.</p>
-<p>Benchmarks based on <a href="https://github.com/ocamllabs/sandmark">sandmark</a> are available at <a href="http://bench2.ocamllabs.io/">bench2.ocamllabs.io</a>
+${OCAMLSPEED_ABOUT_BENCHMARKS_BLOCK}
 <h3>About MyProject</h3>
-<p>The ocaml compiler code can be found <a href="https://github.com/ocaml/ocaml">here</a>.</p>
+${OCAMLSPEED_ABOUT_MYPROJECT_BLOCK}
 <h3>About Codespeed</h3>
 Codespeed is a web application to monitor and analyze the performance of your code.
 <p>Code: <a href="http://github.com/tobami/codespeed">github.com/tobami/codespeed</a></p>
 <p>Wiki: <a href="http://wiki.github.com/tobami/codespeed/">wiki.github.com/tobami/codespeed/</a></p>
 <h3>Contact</h3>
-<p>For problems or suggestions about this website write to ctk21@cl.cam.ac.uk</p>
+${OCAMLSPEED_ABOUT_CONTACT_BLOCK}
 </div>
 {% endblock %}


### PR DESCRIPTION
This PR:
 - reorders the Dockerfile install sequence to make dev-test cycle quicker. 
 - puts in hooks to allow the configuration of the about.html file on the site. 
 - updates the README to match and adds a bit more to help get people started. 